### PR TITLE
#33 bug/GitHub token dosen't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Currently, there is no maven repository set up. However, that is a priority at t
 The maven repo is found at [https://maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/](https://maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/)
 (link will return error but it is there)  
 
-the current vendor json link is `https://harlanhaller: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@maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/nfrlib-json/1.0/nfrlib-json-1.0.json`
+the current vendor json link is `https://${key}@maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/nfrlib-json/1.0/nfrlib-json-1.0.json`  
+
+`${key}` is used in replace of the actual key because github would revoke the key if it was placed in the repo
 
 
 ## Publishing (Dev only)

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,11 @@ task generateVendorJson() {
     outputs.file libFileOutput
     inputs.file libFileInput
 
+    def github_key
+    'http://www.ethersmith.com/frc172/github.txt'.toURL().withReader { reader ->
+      github_key = reader.readLine()
+    }
+
     doLast {
         println "Writing version ${pubVersion} to $libFileOutput"
 
@@ -100,6 +105,7 @@ task generateVendorJson() {
 
         def read = libFileInput.text.replace('${lib_version}', pubVersion)
         read = read.replace('${json_version}', json_version)
+        read = read.replace('${key}', github_key)
         libFileOutput.write(read)
     }
     outputs.upToDateWhen { false }

--- a/src/generate/NFRLib.json.in
+++ b/src/generate/NFRLib.json.in
@@ -4,9 +4,9 @@
   "version": "${lib_version}",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004 ",
   "mavenUrls": [
-    "https://harlanhaller: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@maven.pkg.github.com/northernforce/nfr-lib/"
+    "https://${key}@maven.pkg.github.com/northernforce/nfr-lib/"
   ],
-  "jsonUrl": "https://harlanhaller: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@maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/nfrlib-json/${json_version}/nfrlib-json-${json_version}.json",
+  "jsonUrl": "https://${key}@maven.pkg.github.com/northernforce/nfr-lib/com/northernforce/nfrlib-json/${json_version}/nfrlib-json-${json_version}.json",
   "javaDependencies": [
     {
       "groupId": "com.northernforce",


### PR DESCRIPTION
The key used is now under the team GitHub account
It is currently being hosted on Luke's personal server __We should change that as soon as possible__
<br>
Oh explanation:  
The key is pulled from a file hosted online and injected into the vendor JSON file. That way it will never be committed.  _I think_