### PR TITLE
Bunch of NavX fixes

### DIFF
--- a/src/main/java/org/northernforce/commands/NFRSwerveDriveWithJoystick.java
+++ b/src/main/java/org/northernforce/commands/NFRSwerveDriveWithJoystick.java
@@ -60,6 +60,7 @@ public class NFRSwerveDriveWithJoystick extends Command
         ChassisSpeeds speeds = new ChassisSpeeds(xSupplier.getAsDouble(), ySupplier.getAsDouble(), thetaSupplier.getAsDouble());
         if (fieldRelative)
             speeds = ChassisSpeeds.fromFieldRelativeSpeeds(speeds, drive.getRotation());
+        speeds = ChassisSpeeds.discretize(speeds, 0.02);
         SwerveModuleState[] states = drive.toModuleStates(speeds);
         for (int i = 0; i < states.length; i++)
         {

--- a/src/main/java/org/northernforce/gyros/NFRNavX.java
+++ b/src/main/java/org/northernforce/gyros/NFRNavX.java
@@ -54,7 +54,7 @@ public class NFRNavX extends AHRS implements NFRGyro
     @Override
     public Rotation2d getGyroYaw()
     {
-        return Rotation2d.fromDegrees(getYaw());
+        return Rotation2d.fromDegrees(-getYaw());
     }
     /**
      * Gets the current rotational state of the gyroscope.

--- a/vendordeps/NavX.json
+++ b/vendordeps/NavX.json
@@ -1,7 +1,7 @@
 {
     "fileName": "NavX.json",
     "name": "NavX",
-    "version": "2024.0.1-beta-4",
+    "version": "2024.1.0",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-frc-java",
-            "version": "2024.0.1-beta-4"
+            "version": "2024.1.0"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-frc-cpp",
-            "version": "2024.0.1-beta-4",
+            "version": "2024.1.0",
             "headerClassifier": "headers",
             "sourcesClassifier": "sources",
             "sharedLibrary": false,


### PR DESCRIPTION
NavX is the WORST library. We will never use NavX again. Context: NavX, without warning or documentation, inverted their yaw.