### PR TITLE
Fix resetAngle() in NFRSwerveModule

### DIFF
--- a/src/main/java/org/northernforce/subsystems/drive/swerve/NFRSwerveModule.java
+++ b/src/main/java/org/northernforce/subsystems/drive/swerve/NFRSwerveModule.java
@@ -269,14 +269,14 @@ public class NFRSwerveModule extends NFRSubsystem
     {
         if (externalEncoder.isPresent())
         {
-            externalEncoder.get().setAbsoluteOffset(angle.getRotations() - externalEncoder.get().getAbsolutePosition()
-                + externalEncoder.get().getAbsoluteOffset());
+            externalEncoder.get().setAbsoluteOffset(MathUtil.inputModulus(angle.getRotations() - externalEncoder.get().getAbsolutePosition()
+                + externalEncoder.get().getAbsoluteOffset(), 0, 1));
         }
         else if (turnController.getSelectedEncoder() instanceof NFRAbsoluteEncoder)
         {
             NFRAbsoluteEncoder encoder = (NFRAbsoluteEncoder)turnController.getSelectedEncoder();
-            encoder.setAbsoluteOffset(angle.getRotations() - encoder.getAbsolutePosition()
-                + encoder.getAbsoluteOffset());
+            encoder.setAbsoluteOffset(MathUtil.inputModulus(angle.getRotations() - encoder.getAbsolutePosition()
+                + encoder.getAbsoluteOffset(), 0, 1));
         }
     }
     /**

--- a/src/main/java/org/northernforce/subsystems/drive/swerve/NFRSwerveModule.java
+++ b/src/main/java/org/northernforce/subsystems/drive/swerve/NFRSwerveModule.java
@@ -270,13 +270,13 @@ public class NFRSwerveModule extends NFRSubsystem
         if (externalEncoder.isPresent())
         {
             externalEncoder.get().setAbsoluteOffset(MathUtil.inputModulus(angle.getRotations() - externalEncoder.get().getAbsolutePosition()
-                + externalEncoder.get().getAbsoluteOffset(), 0, 1));
+                + externalEncoder.get().getAbsoluteOffset(), 0, externalEncoder.get().getConversionFactor()));
         }
         else if (turnController.getSelectedEncoder() instanceof NFRAbsoluteEncoder)
         {
             NFRAbsoluteEncoder encoder = (NFRAbsoluteEncoder)turnController.getSelectedEncoder();
             encoder.setAbsoluteOffset(MathUtil.inputModulus(angle.getRotations() - encoder.getAbsolutePosition()
-                + encoder.getAbsoluteOffset(), 0, 1));
+                + encoder.getAbsoluteOffset(), 0, encoder.getConversionFactor()));
         }
     }
     /**


### PR DESCRIPTION
Phoenix6 apparently caps the angle for the modules at [-1, 1]. That means the first few calibrations would have worked, the math was correct, except it would have gotten stuck at 1 at some point, which it did.